### PR TITLE
Add toprank to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [SEMrush](https://www.semrush.com/) - Provides keyword research, competitor analysis, and site auditing tools.
 - [Moz Pro](https://moz.com/products/pro) - Offers a suite of SEO tools, including keyword research, link analysis, and site auditing.
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) - A powerful website crawler that helps with technical SEO audits.
+- [toprank](https://github.com/nowork-studio/toprank) - An open-source Claude Code plugin that runs SEO audits using real Google Search Console and PageSpeed Insights data, rewrites meta tags, generates JSON-LD schema markup, and ships the fixes directly to your repo or CMS.
 
 ## Guides and Tutorials
 - [Google's Search Engine Optimization (SEO) Starter Guide](https://support.google.com/webmasters/answer/7451184) - A comprehensive guide by Google on the basics of SEO.


### PR DESCRIPTION
Adds **toprank** under Tools.

toprank is an open-source (MIT) Claude Code plugin that pulls real Google Search Console and PageSpeed Insights data, runs SEO audits, rewrites meta tags, generates JSON-LD schema markup, and ships fixes directly to your repo or CMS connectors (WordPress, Strapi, Contentful, Ghost).

- Source: https://github.com/nowork-studio/toprank
- License: MIT